### PR TITLE
add AWS_SECURITY_TOKEN to be compatible with ol school boto

### DIFF
--- a/bin/assume-aws-role.js
+++ b/bin/assume-aws-role.js
@@ -94,6 +94,9 @@ STS.assumeRole({
   modEnv.AWS_ACCESS_KEY_ID = data.Credentials.AccessKeyId;
   modEnv.AWS_SECRET_ACCESS_KEY = data.Credentials.SecretAccessKey;
   modEnv.AWS_SESSION_TOKEN = data.Credentials.SessionToken;
+
+  // required for boto sts to work
+  modEnv.AWS_SECURITY_TOKEN = data.Credentials.SessionToken;
   modEnv.PS1 = "(assume-aws-role " + command + ")$ ";
 
   spawn(process.env.SHELL, {


### PR DESCRIPTION
boto looks for in the env variable `AWS_SECURITY_TOKEN` for the sts token, not `AWS_SESSION_TOKEN`. Adding in a copy of it makes boto work.
