### PR TITLE
updating module versions and adding a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+1.3.1
+------------------
+- Updating the aws-sdk to `2.4.3` and fs-extra to `0.30.0`, currently these are the latest for both modules, the fs-extra upgrade fixes a warning that was appearing with node v6.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "aws-sdk": "^2.1.27",
-    "fs-extra": "^0.18.3"
+    "aws-sdk": "^2.4.3",
+    "fs-extra": "^0.30.0"
   }
 }


### PR DESCRIPTION
I was hitting a warning when using this with node `6.0.0` updating the fs-extra to `0.21.0` actually resolves the warning, but I went ahead and updated to the latest for fs-extra and the aws-sdk.  I've been using it with these newer versions without issue, but I only have access to test this on a Mac.  I also added a changelog file to track changes.
