### PR TITLE
Add the current directory to the shell prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Now you can assume that role we just added:
 
 Now you've got a shell with your temporary security credentials in the environment:
 
-`(assume-aws-role sandbox)$ `
+`(assume-aws-role sandbox):~/ $ `
 
 You can also add roles without MFA devices:
 

--- a/bin/assume-aws-role.js
+++ b/bin/assume-aws-role.js
@@ -137,7 +137,7 @@ STS.assumeRole({
 
   // required for boto sts to work
   modEnv.AWS_SECURITY_TOKEN = data.Credentials.SessionToken;
-  modEnv.PS1 = "(assume-aws-role " + command + ")$ ";
+  modEnv.PS1 = "(assume-aws-role " + command + "):\\w $ ";
 
   spawn(process.env.SHELL, {
     env: modEnv,


### PR DESCRIPTION
Often times it's helpful to understand which directory you're in when issuing commands.  This PR will add the current working directory to the shell prompt.  I've also updated the README to reflect the shell prompt.
