### PR TITLE
Return the return code from the shell.

### DIFF
--- a/bin/assume-aws-role.js
+++ b/bin/assume-aws-role.js
@@ -140,8 +140,13 @@ STS.assumeRole({
   modEnv.PS1 = "(assume-aws-role " + command + ")$ ";
   modEnv.ASSUME_AWS_ROLE = command;
 
-  spawn(process.env.SHELL, {
+  var sh = spawn(process.env.SHELL, {
     env: modEnv,
     stdio: "inherit"
   });
+
+  sh.on('close',(code)=>{
+       process.exit(code);
+  });
+
 });


### PR DESCRIPTION
When using the assume-aws-role command as part of a script, it would be convenient to receive the return code from the shell spawn

Example:

`echo "aws s3 sync ... " | assume-aws-role myrole
`
will  return the return code from the aws s3 command .

Signed-off-by: Pablo <pablochacin@gmail.com>